### PR TITLE
feat: Password Update user dashboard

### DIFF
--- a/src/api/userServices.ts
+++ b/src/api/userServices.ts
@@ -46,3 +46,28 @@ export const signup = async (userData: {
   const response = await apiClient.post("/user/signup", userData);
   return response.data;
 };
+export const changePassword = async (currentPassword: string, newPassword: string) => {
+  try {
+    const response = await apiClient.post('/user/change-password', {
+      currentPassword,
+      newPassword,
+    });
+
+    // Access status code and message from the response
+    const { status, data } = response;
+    console.log(status, data);
+    if (status === 401) {
+      // Handle unauthorized response
+      console.error(data.message || 'Unauthorized');
+    } else if (status === 200) {
+      // Handle success response
+      console.log(data.message || 'Password updated successfully');
+    }
+
+    return data;
+  } catch (error) {
+    // Handle errors from the API call
+    console.error('An error occurred:', error);
+    throw error;  // Re-throw the error to be handled by the caller
+  }
+};

--- a/src/components/Profile/ProfileForm/index.tsx
+++ b/src/components/Profile/ProfileForm/index.tsx
@@ -5,6 +5,7 @@ import ColorButton from "../../ColorButton";
 import ProfileTextField from "../ProfileTextField";
 import ProfilePasswordField from "../ProfilePasswordField";
 import { validateProfileForm } from "../../../utils/validateProfileForm";
+import FormChangePassword from "../../../pages/FormChangePassword";
 
 interface ProfileFormProps {
   user: Partial<User>;
@@ -16,6 +17,7 @@ const ProfileForm = ({ user, onSave, isEditing }: ProfileFormProps) => {
   const [formValues, setFormValues] = useState<Partial<User>>({ ...user });
   const [isPasswordEditing, setIsPasswordEditing] = useState(false);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     if (isEditing) {
@@ -51,11 +53,15 @@ const ProfileForm = ({ user, onSave, isEditing }: ProfileFormProps) => {
       }
 
       onSave(updatedUser);
-    } 
+    }
   };
 
   const handlePasswordIconClick = () => {
-    setIsPasswordEditing(true);
+    setOpen(true);
+  };
+
+  const handlePasswordModalClose = () => {
+    setOpen(false);
   };
 
   return (
@@ -89,7 +95,7 @@ const ProfileForm = ({ user, onSave, isEditing }: ProfileFormProps) => {
         </Grid>
         <Grid item xs={12} sm={6}>
           <ProfilePasswordField
-            value="********"
+            value="**"
             onChange={handleInputChange}
             onPasswordIconClick={handlePasswordIconClick}
             isPasswordEditing={isPasswordEditing}
@@ -185,6 +191,7 @@ const ProfileForm = ({ user, onSave, isEditing }: ProfileFormProps) => {
           </ColorButton>
         </Grid>
       </Grid>
+      <FormChangePassword open={open} onClose={handlePasswordModalClose} />
     </Box>
   );
 };

--- a/src/components/Profile/ProfilePasswordField/index.tsx
+++ b/src/components/Profile/ProfilePasswordField/index.tsx
@@ -16,6 +16,7 @@ interface ProfilePasswordFieldProps {
   autoComplete?: string;
 }
 
+
 const ProfilePasswordField = ({
   value,
   onChange,
@@ -23,6 +24,9 @@ const ProfilePasswordField = ({
   isPasswordEditing,
   autoComplete,
 }: ProfilePasswordFieldProps) => (
+
+  
+
   <>
     <Typography variant="body1" gutterBottom>
       Password

--- a/src/pages/FormChangePassword.tsx
+++ b/src/pages/FormChangePassword.tsx
@@ -1,0 +1,221 @@
+import React, { useState, useEffect } from 'react';
+import { Modal, Typography, TextField, Grid, Button } from '@mui/material';
+import { changePassword } from '../api/userServices';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { isPasswordValid } from '../validations/changePassword';
+import ColorButton from '../components/ColorButton';
+
+interface FormChangePasswordProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const passwordsMatch = (newPassword: string, confirmPassword: string) => newPassword === confirmPassword;
+
+    
+
+
+const FormChangePassword: React.FC<FormChangePasswordProps> = ({ open, onClose }) => {
+  const [formData, setFormData] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+
+  const [errors, setErrors] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  const validateField = (name: string, value: string) => {
+    let error = '';
+
+    if (name === 'currentPassword') {
+      if (!value) {
+        error = 'Contraseña requerida.';
+      }
+    }
+
+    if (name === 'newPassword') {
+      if (!value) {
+        error = 'Nueva contraseña requerida.';
+      } else if (!isPasswordValid(value)) {
+        error = 'La contraseña debe tener al menos 8 caracteres, incluir al menos una letra mayúscula y un símbolo.';
+      }
+    }
+
+    if (name === 'confirmPassword') {
+      if (!value) {
+        error = 'Por favor confirme la contraseña.';
+      } else if (value !== formData.newPassword) {
+        error = 'Contraseñas no coinciden.';
+      }
+    }
+
+    return error;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+
+    // Validate field on change
+    const error = validateField(name, value);
+    setErrors({ ...errors, [name]: error });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+  
+    // Validate all fields before submission
+    const currentPasswordError = validateField('currentPassword', formData.currentPassword);
+    const newPasswordError = validateField('newPassword', formData.newPassword);
+    const confirmPasswordError = validateField('confirmPassword', formData.confirmPassword);
+  
+    if (currentPasswordError || newPasswordError || confirmPasswordError) {
+      setErrors({
+        currentPassword: currentPasswordError,
+        newPassword: newPasswordError,
+        confirmPassword: confirmPasswordError,
+      });
+      return;
+    }
+  
+    try {
+        // Asumiendo que ya validaste los campos antes de este bloque de código
+        const response = await changePassword(formData.currentPassword, formData.newPassword);
+        console.log(response.statusCode, response.message);
+      
+        switch (response.statusCode) {
+          case 401:
+            alert('La contraseña actual no coincide.');
+            break;
+          case 200:
+            alert('Contraseña cambiada con éxito');
+            break;
+          case 422: // Asumiendo que 422 es el código de estado para errores de validación
+            alert('Error de validación. Por favor, revisa los campos.');
+            break;
+          default:
+            alert('Error desconocido al cambiar la contraseña');
+            break;
+        }
+      } catch (error) {
+        console.error('Error al cambiar la contraseña:', error);
+        alert('Error al cambiar la contraseña');
+        }
+    };
+
+  const handleClose = () => {
+   
+    setFormData({
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    });
+    setErrors({
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    });
+    
+  };
+
+  const handleCancel = () => {
+    onClose();
+    handleClose();
+    };
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="change-password-modal-title"
+      aria-describedby="change-password-modal-description"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div style={{ backgroundColor: 'white', padding: '40px', maxWidth: '600px', width: '100%', borderRadius: '10px'}}>
+        <Typography id="change-password-modal-title" variant="h6" component="h2" sx={{ fontWeight: 'bold' }}>
+          Cambiar Contraseña
+        </Typography>
+        <form onSubmit={handleSubmit}>
+          <Grid container spacing={2}>
+            <Grid item xs={12}>
+              <TextField
+                error={!!errors.currentPassword}
+                helperText={errors.currentPassword}
+                margin="dense"
+                required
+                fullWidth
+                name="currentPassword"
+                label="Contraseña Actual"
+                type="password"
+                value={formData.currentPassword}
+                onChange={handleChange}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                error={!!errors.newPassword}
+                helperText={errors.newPassword}
+                margin="dense"
+                required
+                fullWidth
+                name="newPassword"
+                label="Nueva Contraseña"
+                type="password"
+                value={formData.newPassword}
+                onChange={handleChange}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                error={!!errors.confirmPassword}
+                helperText={errors.confirmPassword}
+                margin="dense"
+                required
+                fullWidth
+                name="confirmPassword"
+                label="Confirmar Nueva Contraseña"
+                type="password"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+              />
+            </Grid>
+          </Grid>
+
+          <ColorButton type="submit" fullWidth variant="contained" sx={{ mt: 3 }} disabled={!isPasswordValid(formData.confirmPassword)}>
+            Guardar
+          </ColorButton>
+          <ColorButton onClick={handleCancel} fullWidth variant="contained" sx={{ mt: 3 }}>
+            Cancelar
+          </ColorButton>
+          
+        </form>
+      </div>
+    </Modal>
+  );
+};
+
+export default FormChangePassword;

--- a/src/validations/changePassword.tsx
+++ b/src/validations/changePassword.tsx
@@ -1,0 +1,14 @@
+
+
+
+export const isPasswordValid = (password: string): boolean => {
+    // Define password validation criteria
+    const passwordRegex = /^(?=.*[A-Z])(?=.*[!@#$%^&*])(?=.*\d)[A-Za-z\d!@#$%^&*]{8,}$/;
+    // ^(?=.*[A-Z]) - at least one uppercase letter
+    // (?=.*[!@#$%^&*]) - at least one special character
+    // (?=.*\d) - at least one digit
+    // {8,} - at least 8 characters long
+    
+    // Validate password format
+    return passwordRegex.test(password);
+  };


### PR DESCRIPTION
This component allows users to change their password within a modal dialog. It includes fields for the current password, new password, and confirmation of the new password, with validation to ensure the new passwords match and meet security criteria. Upon submission, it calls an API to update the password and provides feedback based on the response. The form also includes a cancel button to close the modal without making changes.

<img width="369" alt="Capturaa" src="https://github.com/user-attachments/assets/12909860-d573-420b-b36e-e0785f2ad552">
